### PR TITLE
Fix crash on reloading A-Frame when switching from livestream to local video

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,6 +143,7 @@
                 fileName + iconHtml;
             
             /* Delete the current a-frame scene */
+			document.querySelector('a-scene').exitVR();
             var oldScene = document.querySelector('a-scene');
             oldScene.parentNode.removeChild(oldScene);
 
@@ -183,6 +184,7 @@
 
         function stopLocalVideo() {
             /* Delete the local playback a-frame scene */
+			document.querySelector('a-scene').exitVR();
             var oldScene = document.querySelector('a-scene');
             oldScene.parentNode.removeChild(oldScene);
 


### PR DESCRIPTION
Updated index.html to have exitVR() on lines 146 and 187. This fixes a bug where VR stops working upon switching scenes where the a-frame scene is deleted.